### PR TITLE
Legger til støtte for adresseTilleggsnavn fra NORG.

### DIFF
--- a/src/components/SingleReception/SingleReception.module.scss
+++ b/src/components/SingleReception/SingleReception.module.scss
@@ -103,6 +103,11 @@ $metadataIndent: 34px;
     }
 }
 
+.addressExtra {
+    @extend .addressLine;
+    margin-bottom: 0;
+}
+
 .appointmentBookingInfo {
     display: flex;
     gap: 0.375rem;

--- a/src/components/SingleReception/SingleReception.tsx
+++ b/src/components/SingleReception/SingleReception.tsx
@@ -16,7 +16,7 @@ export const SingleReception = (props: SingleReceptionProps) => {
     const { language } = props;
     const getLabel = translator('office', language);
 
-    const { address, adkomstbeskrivelse, openingHours, openingHoursExceptions } = formatAudienceReception(props);
+    const { address, adkomstbeskrivelse, openingHours, openingHoursExceptions, addressExtra } = formatAudienceReception(props);
     const futureOpeningHoursExceptions = getFutureOpeningExceptions(openingHoursExceptions);
 
     const hasOpeningHours = openingHours.length > 0 || futureOpeningHoursExceptions.length > 0;
@@ -29,6 +29,7 @@ export const SingleReception = (props: SingleReceptionProps) => {
                 {getLabel('address')}
             </Heading>
             <section className={style.address}>
+                {addressExtra && <BodyShort className={style.addressExtra}>{addressExtra}</BodyShort>}
                 <BodyShort className={style.addressLine}>{address}</BodyShort>
                 {adkomstbeskrivelse && (
                     <BodyShort className={style.addressLine} size="small">

--- a/src/components/SingleReception/formatAudienceReception.ts
+++ b/src/components/SingleReception/formatAudienceReception.ts
@@ -9,6 +9,7 @@ type OpeningHoursBuckets = {
 type FormattedAudienceReception = {
     address: string;
     adkomstbeskrivelse?: string;
+    addressExtra?: string;
     openingHours: OpeningHoursProps[];
     openingHoursExceptions: OpeningHoursProps[];
 };
@@ -36,6 +37,7 @@ export const formatAudienceReception = (audienceReception: AudienceReception): F
 
     return {
         address: formatAddress(audienceReception.besoeksadresse),
+        addressExtra: audienceReception.besoeksadresse?.adresseTilleggsnavn,
         openingHoursExceptions: aapningstider?.exceptions || [],
         openingHours,
         adkomstbeskrivelse: audienceReception.adkomstbeskrivelse,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,6 +1,7 @@
 export type Address = {
     type?: 'stedsadresse';
     postnummer?: string;
+    adresseTilleggsnavn?: string;
     poststed?: string;
     gatenavn?: string;
     husnummer?: string;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
NORG har et felt, adresseTilleggsnavn, som ikke brukes pr i dag, men som vi ønsker å vise under publikumsmottak hvis det er tilgjengelig.

Eksempler på adresseTilleggsnavn er "Rådhuset", "Meråker kommunehus" og andre korte anvisninger som gir en bedre forståelse av adressen.

## Testing
Testes i nav-enonicxp-frontend.

