### PR TITLE
Support react 18 og 19 og forbedrer publisering av beta

### DIFF
--- a/.github/workflows/npm-publish-beta.yml
+++ b/.github/workflows/npm-publish-beta.yml
@@ -17,15 +17,17 @@ jobs:
                   node-version: '20'
                   registry-url: 'https://npm.pkg.github.com'
                   cache: 'npm'
-            - name: Bump version
-              run: |
-                  git config --global user.name '${{ github.actor }}'
-                  git config --global user.email '${{ github.actor }}@users.noreply.github.com'
-                  npm version prerelease --preid beta
             - name: Install dependencies
               run: npm ci
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+            - name: Bump version
+              id: version-bump
+              run: |
+                  git config --global user.name '${{ github.actor }}'
+                  git config --global user.email '${{ github.actor }}@users.noreply.github.com'
+                  VERSION_TAG=$(npm version prerelease --preid beta)
+                  echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
             - name: Build package
               run: npm run build
             - name: Publish package
@@ -33,6 +35,24 @@ jobs:
               run: npm publish --tag beta
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Push new version tag
+            - name: Push version changes
               if: steps.publish.outcome == 'success'
-              run: git push origin --tags
+              run: git push origin HEAD:${{ github.ref_name }}
+            - name: Create beta release
+              if: steps.publish.outcome == 'success'
+              uses: softprops/action-gh-release@v1
+              with:
+                  tag_name: ${{ steps.version-bump.outputs.version_tag }}
+                  name: ${{ steps.version-bump.outputs.version_tag }} (Beta)
+                  body: |
+                      🧪 **Beta Release**
+
+                      This is a pre-release version for testing purposes.
+
+                      **Installation:**
+                      ```bash
+                      npm install @navikt/nav-office-reception-info@beta
+                      ```
+
+                      Please report any issues you encounter!
+                  prerelease: true

--- a/.github/workflows/npm-publish-release.yml
+++ b/.github/workflows/npm-publish-release.yml
@@ -33,15 +33,18 @@ jobs:
                   node-version: '20'
                   registry-url: 'https://npm.pkg.github.com'
                   cache: 'npm'
-            - name: Bump version
-              run: |
-                  git config --global user.name '${{ github.actor }}'
-                  git config --global user.email '${{ github.actor }}@users.noreply.github.com'
-                  echo "VERSION_TAG=$(npm version ${{ github.event.inputs.releaseType }})" >> $GITHUB_ENV
             - name: Install dependencies
               run: npm ci
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+            - name: Bump version
+              id: version-bump
+              run: |
+                  git config --global user.name '${{ github.actor }}'
+                  git config --global user.email '${{ github.actor }}@users.noreply.github.com'
+                  VERSION_TAG=$(npm version ${{ github.event.inputs.releaseType }})
+                  echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
+                  echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
             - name: Build package
               run: npm run build
             - name: Publish package
@@ -49,11 +52,11 @@ jobs:
               run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Push new version tag
+            - name: Push version changes
               if: steps.publish.outcome == 'success'
-              run: git push origin --tags
+              run: git push origin HEAD:${{ github.ref_name }}
             - name: Create release
               uses: softprops/action-gh-release@v1
               with:
-                  tag_name: ${{ env.VERSION_TAG }}
+                  tag_name: ${{ steps.version-bump.outputs.version_tag }}
                   body: ${{ github.event.inputs.releaseBody }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/nav-office-reception-info",
-    "version": "1.2.2",
+    "version": "1.2.3-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/nav-office-reception-info",
-            "version": "1.2.2",
+            "version": "1.2.3-beta.1",
             "devDependencies": {
                 "@eslint/compat": "^1.1.1",
                 "@types/node": "20.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/nav-office-reception-info",
-    "version": "1.2.3-beta.1",
+    "version": "1.2.3-beta.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/nav-office-reception-info",
-            "version": "1.2.3-beta.1",
+            "version": "1.2.3-beta.2",
             "devDependencies": {
                 "@eslint/compat": "^1.1.1",
                 "@types/node": "20.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,26 @@
 {
     "name": "@navikt/nav-office-reception-info",
-    "version": "1.2.0",
+    "version": "1.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/nav-office-reception-info",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "devDependencies": {
                 "@eslint/compat": "^1.1.1",
                 "@types/node": "20.12.4",
-                "@types/react": "18.3.9",
-                "@types/react-dom": "18.3.0",
+                "@types/react": "^18.3.9",
+                "@types/react-dom": "^18.3.0",
                 "@typescript-eslint/eslint-plugin": "8.7.0",
                 "@typescript-eslint/parser": "8.7.0",
-                "@vitejs/plugin-react-swc": "^3.9.0",
+                "@vitejs/plugin-react-swc": "3.9.0",
                 "eslint": "9.11.1",
                 "eslint-plugin-react-hooks": "5.1.0-rc-778e1ed2-20240926",
                 "eslint-plugin-react-refresh": "0.4.12",
                 "sass": "1.79.3",
                 "typescript": "5.5.4",
-                "vite": "^6.3.3",
+                "vite": "6.3.3",
                 "vite-plugin-dts": "4.2.2",
                 "vite-plugin-lib-inject-css": "2.1.1"
             },
@@ -29,8 +29,8 @@
                 "@navikt/ds-css": "^7.1.0",
                 "@navikt/ds-react": "^7.1.0",
                 "dayjs": "^1.11.10",
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
+                "react": "^18.2.0 || ^19.0.0",
+                "react-dom": "^18.2.0 || ^19.0.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
         "@navikt/ds-css": "^7.1.0",
         "@navikt/ds-react": "^7.1.0",
         "dayjs": "^1.11.10",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
     },
     "comment": {
         "dependencies": {
@@ -41,8 +41,8 @@
     "devDependencies": {
         "@eslint/compat": "^1.1.1",
         "@types/node": "20.12.4",
-        "@types/react": "18.3.9",
-        "@types/react-dom": "18.3.0",
+        "@types/react": "^18.3.9",
+        "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "8.7.0",
         "@typescript-eslint/parser": "8.7.0",
         "@vitejs/plugin-react-swc": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@navikt/nav-office-reception-info",
     "author": "NAVIKT",
-    "version": "1.2.3-beta.1",
+    "version": "1.2.3-beta.2",
     "type": "module",
     "main": "dist/main.js",
     "types": "dist/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@navikt/nav-office-reception-info",
     "author": "NAVIKT",
-    "version": "1.2.2",
+    "version": "1.2.3-beta.0",
     "type": "module",
     "main": "dist/main.js",
     "types": "dist/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@navikt/nav-office-reception-info",
     "author": "NAVIKT",
-    "version": "1.2.3-beta.0",
+    "version": "1.2.3-beta.1",
     "type": "module",
     "main": "dist/main.js",
     "types": "dist/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": "NAVIKT",
     "version": "1.2.2",
     "type": "module",
-    "main": "dist/nav-office-reception-info.js",
+    "main": "dist/main.js",
     "types": "dist/main.d.ts",
     "files": [
         "dist"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,9 +10,19 @@ export default defineConfig({
         lib: {
             entry: resolve(__dirname, 'src/main.ts'),
             formats: ['es'],
+            fileName: 'main',
         },
         rollupOptions: {
             external: ['react', 'react/jsx-runtime', '@navikt/ds-react', 'dayjs'],
+            output: {
+                assetFileNames: (assetInfo) => {
+                    const name = assetInfo.names?.[0] || assetInfo.originalFileNames?.[0] || '';
+                    if (name.includes('.css') || (assetInfo.type === 'asset' && name.endsWith('.css'))) {
+                        return 'style.css';
+                    }
+                    return name;
+                },
+            },
         },
     },
 });


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Tillater React 19.x. Ser ikke ut til å være noen breaking changes som treffer denne applikasjonen.
- Forbedrer workflow slik at også betaer blir publisert riktig.

## Testing
Testes i beta-publisering
