### PR TITLE
Tvinger array dersom vi har fått feil format fra XP på aapningstider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@navikt/nav-office-reception-info",
-    "version": "1.4.3",
+    "version": "1.4.4-beta.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@navikt/nav-office-reception-info",
-            "version": "1.4.3",
+            "version": "1.4.4-beta.0",
             "devDependencies": {
                 "@eslint/compat": "^1.1.1",
                 "@types/node": "20.12.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@navikt/nav-office-reception-info",
     "author": "NAVIKT",
-    "version": "1.4.3",
+    "version": "1.4.4-beta.0",
     "type": "module",
     "main": "dist/main.js",
     "types": "dist/main.d.ts",

--- a/src/components/SingleReception/formatAudienceReception.ts
+++ b/src/components/SingleReception/formatAudienceReception.ts
@@ -1,5 +1,5 @@
 import { AudienceReception, OpeningHours as OpeningHoursProps } from '../../utils/types.ts';
-import { formatAddress } from '../../utils/utils.ts';
+import { forceArray, formatAddress } from '../../utils/utils.ts';
 
 type OpeningHoursBuckets = {
     regular: OpeningHoursProps[];
@@ -17,7 +17,7 @@ type FormattedAudienceReception = {
 const dagArr: OpeningHoursProps['dag'][] = ['Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag'] as const;
 
 export const formatAudienceReception = (audienceReception: AudienceReception): FormattedAudienceReception => {
-    const aapningstider = audienceReception.aapningstider?.reduce<OpeningHoursBuckets>(
+    const aapningstider = forceArray<OpeningHoursProps>(audienceReception.aapningstider).reduce<OpeningHoursBuckets>(
         (acc, elem) => {
             if (elem.dato) {
                 acc.exceptions.push(elem);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -41,3 +41,13 @@ export const formatDate = ({ datetime, language = 'nb', short = false, year = fa
 
     return datetime ? dayjs(datetime).locale(currentLocale).format(format) : datetime;
 };
+
+export const forceArray = <T>(data: T | T[]): T[] => {
+    if (!data) {
+        return [];
+    }
+    if (Array.isArray(data)) {
+        return data;
+    }
+    return [data];
+};


### PR DESCRIPTION
## Oppsummering av hva som er gjort
XP kan ved noen anledninger levere et objekt i stedet for en array dersom det kun finnes én åpningstid. Legger inn en fail safe.

## Testing
Testes som beta i dev for nav-frontend