### PR TITLE
Fiks: .d.ts-filer i dist-rot (typer for konsumenter)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import { esmExternalRequirePlugin } from 'rolldown/plugins';
 export default defineConfig({
     plugins: [
         react(),
-        dts({ include: ['src'] }),
+        dts({ include: ['src'], entryRoot: 'src' }),
         esmExternalRequirePlugin({ external: ['react', 'react/jsx-runtime', '@navikt/ds-react', 'dayjs'] }),
     ],
     build: {


### PR DESCRIPTION
2.0.1 publiserte typene til dist/src/ mens package.json peker på dist/main.d.ts. Konsumenter (f.eks. nav-enonicxp-frontend) fikk TS7016 'Could not find a declaration file'.

entryRoot: 'src' stripper src-prefikset så:
- dist/main.d.ts finnes (matcher package.json types)
- dist/utils/types.d.ts finnes (matcher konsument-import)

Fikser problemet ved kilden – ingen tsconfig-workaround i hvert konsument-repo.